### PR TITLE
Initialize Go modules and update JWT auth code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a `golang` library for interfacing with `Salesforce` APIs.
 ### Installing
 To start using GO-SFDC, install GO and run `go get`
 ```
-go get -u github.com/g8rswimmer/go-sfdc
+go get -u github.com/elastic/go-sfdc
 ```
 This will retrieve the library.
 

--- a/bulk/bulk.go
+++ b/bulk/bulk.go
@@ -3,7 +3,7 @@ package bulk
 import (
 	"errors"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 const bulk2Endpoint = "/jobs/ingest"

--- a/bulk/bulk_test.go
+++ b/bulk/bulk_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func TestNewResource(t *testing.T) {

--- a/bulk/job.go
+++ b/bulk/job.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"strings"
 
-	sfdc "github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	sfdc "github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // JobType is the bulk job type.

--- a/bulk/job_test.go
+++ b/bulk/job_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func TestJob_formatOptions(t *testing.T) {

--- a/bulk/jobs.go
+++ b/bulk/jobs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strconv"
 
-	sfdc "github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	sfdc "github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Parameters to query all of the bulk jobs.

--- a/bulk/jobs_test.go
+++ b/bulk/jobs_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func TestJobs_do(t *testing.T) {

--- a/composite/batch/batch.go
+++ b/composite/batch/batch.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Subrequester provides the composite batch API requests.

--- a/composite/batch/batch_test.go
+++ b/composite/batch/batch_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockSubrequester struct {

--- a/composite/composite.go
+++ b/composite/composite.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Subrequester provides the composite API requests.  The

--- a/composite/composite_test.go
+++ b/composite/composite_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockSubrequester struct {

--- a/config.go
+++ b/config.go
@@ -3,7 +3,7 @@ package sfdc
 import (
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc/credentials"
+	"github.com/elastic/go-sfdc/credentials"
 )
 
 // Configuration is the structure for goforce sessions.

--- a/credentials/jwt.go
+++ b/credentials/jwt.go
@@ -2,11 +2,12 @@ package credentials
 
 import (
 	"fmt"
-	"github.com/dgrijalva/jwt-go"
 	"io"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 const (
@@ -15,10 +16,13 @@ const (
 
 type jwtProvider struct {
 	creds JwtCredentials
+	now   func() time.Time // Function to get the current time, useful for testing
 }
 
 type claims struct {
-	jwt.StandardClaims
+	// Reason for using RegisteredClaims instead of StandardClaims
+	// See: https://github.com/golang-jwt/jwt/blob/62e504c2810b67f6b97313424411cfffb25e41b0/MIGRATION_GUIDE.md?plain=1#L81
+	jwt.RegisteredClaims
 }
 
 func (provider *jwtProvider) Retrieve() (io.Reader, error) {
@@ -39,22 +43,31 @@ func (provider *jwtProvider) URL() string {
 	return provider.creds.URL
 }
 
-func (provider *jwtProvider) GetAppropriateExpirationTime() int64 {
-	return time.Now().Add(JwtExpiration).Unix()
+func (provider *jwtProvider) GetAppropriateExpirationTime() time.Time {
+	if provider.now != nil {
+		return provider.now().Add(JwtExpiration)
+	}
+	return time.Now().Add(JwtExpiration)
 }
 
-// builds the actual claims token required for authentication
-func (provider *jwtProvider) BuildClaimsToken(expirationTime int64, url string, clientId string, clientUsername string) (string, error) {
+func (provider *jwtProvider) BuildClaimsToken(expirationTime time.Time, url string, clientId string, clientUsername string) (string, error) {
 	claims := &claims{
-		StandardClaims: jwt.StandardClaims{
-			// In JWT, the expiry time is expressed as unix milliseconds
-			ExpiresAt: expirationTime,
-			Audience:  url,                  // "https://test.salesforce.com" || "https://login.salesforce.com"
-			Issuer:    clientId, // consumer key of the connected app, hardcoded
-			Subject:   clientUsername,                       // username of the salesforce user, whose profile is added to the connected app
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expirationTime),
+			Audience:  []string{url},
+			Issuer:    clientId,
+			Subject:   clientUsername,
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	tokenString, error := token.SignedString(provider.creds.ClientKey)
-	return tokenString, error
+
+	if provider.creds.ClientKey == nil {
+		return "", fmt.Errorf("jwtProvider.BuildClaimsToken() error: clientKey is nil")
+	}
+
+	tokenString, err := token.SignedString(provider.creds.ClientKey)
+	if err != nil {
+		return "", fmt.Errorf("jwtProvider.BuildClaimsToken() error: failed to sign token: %w", err)
+	}
+	return tokenString, nil
 }

--- a/credentials/jwt_test.go
+++ b/credentials/jwt_test.go
@@ -1,67 +1,150 @@
 package credentials
 
 import (
-	"github.com/dgrijalva/jwt-go"
+	"fmt"
 	"io"
 	"net/url"
-	"strings"
+	"reflect"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
-const SampleKey = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m\n0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa\niks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO\nlh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV\nZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1\noSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad\n4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA\nOntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC\nqJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I\neK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5\ntog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH\n5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q\n+smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ\nN1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK\nP/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP\n+dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP\nyWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5\nPI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm\nQKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE\n2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge\nLDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq\nNGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW\nRHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ\nGqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo\nhQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg\n-----END RSA PRIVATE KEY-----"
+const SampleKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m
+0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa
+iks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO
+lh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV
+ZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1
+oSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad
+4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA
+OntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC
+qJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I
+eK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5
+tog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH
+5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q
++smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ
+N1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK
+P/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP
++dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP
+yWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5
+PI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm
+QKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE
+2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge
+LDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq
+NGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW
+RHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ
+Gqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo
+hQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg
+-----END RSA PRIVATE KEY-----`
 
-
-
-func mockJWTRetriveReader(creds JwtCredentials) io.Reader {
-	form := url.Values{}
-	form.Add("grant_type", string(jwtGrantType))
-
-
-	return strings.NewReader(form.Encode())
+func fixedTime() time.Time {
+	return time.Now()
 }
+
 func Test_jwtProvider_Retrieve(t *testing.T) {
-
 	pemData := []byte(SampleKey)
-
-	signKey, _ := jwt.ParseRSAPrivateKeyFromPEM(pemData)
-
-	type fields struct {
-		creds JwtCredentials
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(pemData)
+	if err != nil {
+		t.Fatalf("Failed to parse RSA private key: %v", err)
 	}
+
 	tests := []struct {
-		name    string
-		fields  fields
-		want    string
-		wantErr bool
+		name          string
+		creds         JwtCredentials
+		expirationAdj time.Duration
+		wantErr       bool
 	}{
-		// TODO: Add test cases.
 		{
-			name: "Token Retriever",
-			fields: fields{
-				creds: JwtCredentials{
-					URL:          "http://test.password.session",
-					ClientId:     "12345",
-					ClientUsername:     "myusername",
-					ClientKey: signKey,
-				},
+			name: "Valid Token",
+			creds: JwtCredentials{
+				URL:            "http://test.password.session",
+				ClientId:       "12345",
+				ClientUsername: "myusername",
+				ClientKey:      signKey,
 			},
-			want: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJodHRwOi8vdGVzdC5wYXNzd29yZC5zZXNzaW9uIiwiZXhwIjoxMjMyMTMsImlzcyI6IjEyMzQ1Iiwic3ViIjoibXl1c2VybmFtZSJ9.rMwIVIG9IEHuZ9O5Na3VZHCRTw0z7iBRugWPlZeq6VFjcrHimDvBxN91DQtQcOqULSORWvo0HGzEHo_LOnMopj6dyL-wxgEp3Fu9owv-69HNP_uYYfy0_W93-1BVlOgCGuF6NdP2JHb3EsUmEPf-DJcjYmiymUMrMV6vNhkbl3eb_V93xA4-sid4reyMyBDVznKqyrQOOiyEqEq3tF9IZKcu7Cr1KDJa2br8S9Rq_xwv6PZPm4Pm97Bpd5t95Fo6zyTIOLu-zaXRzwKBRF6StuXsisfXo66-jDnSs0R-fx_RaI6GRez900lEzqZK13ggsLmB3PqpNcZkWvKvExBSHg",
-			wantErr: false,
+			expirationAdj: JwtExpiration,
+			wantErr:       false,
+		},
+		{
+			name: "Invalid Key",
+			creds: JwtCredentials{
+				URL:            "http://test.password.session",
+				ClientId:       "12345",
+				ClientUsername: "myusername",
+				ClientKey:      nil,
+			},
+			expirationAdj: JwtExpiration,
+			wantErr:       true,
+		},
+		{
+			name: "Expired Token",
+			creds: JwtCredentials{
+				URL:            "http://test.password.session",
+				ClientId:       "12345",
+				ClientUsername: "myusername",
+				ClientKey:      signKey,
+			},
+			expirationAdj: -JwtExpiration,
+			wantErr:       false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider := &jwtProvider{
-				creds: tt.fields.creds,
-			}
-			token, err := provider.BuildClaimsToken(123213, provider.creds.URL, provider.creds.ClientId, provider.creds.ClientUsername)
-
-			if err != nil && !tt.wantErr {
-				t.Error()
+				creds: tt.creds,
+				now:   fixedTime, // Use fixed time for consistency
 			}
 
-			if token != tt.want {
-				t.Error("tokens do not match")
+			expirationTime := fixedTime().Add(tt.expirationAdj)
+			_, err := provider.BuildClaimsToken(expirationTime, provider.creds.URL, provider.creds.ClientId, provider.creds.ClientUsername)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jwtProvider.BuildClaimsToken() error: %v, wantErr: %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				got, err := provider.Retrieve()
+				if err != nil {
+					t.Errorf("jwtProvider.Retrieve() error: %v", err)
+					return
+				}
+
+				b, _ := io.ReadAll(got)
+
+				gotForm, err := url.ParseQuery(string(b))
+				if err != nil {
+					t.Errorf("Failed to parse got form: %v", err)
+					return
+				}
+
+				gotToken := gotForm.Get("assertion")
+				gotClaims := &claims{}
+				_, err = jwt.ParseWithClaims(gotToken, gotClaims, func(token *jwt.Token) (interface{}, error) {
+					if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+						return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+					}
+					return provider.creds.ClientKey.Public(), nil
+				})
+				if err != nil {
+					t.Errorf("Failed to parse got token: %v", err)
+					return
+				}
+
+				wantClaims := &claims{
+					RegisteredClaims: jwt.RegisteredClaims{
+						ExpiresAt: jwt.NewNumericDate(fixedTime().Add(JwtExpiration)),
+						Audience:  []string{provider.creds.URL},
+						Issuer:    provider.creds.ClientId,
+						Subject:   provider.creds.ClientUsername,
+					},
+				}
+
+				if !reflect.DeepEqual(gotClaims, wantClaims) {
+					t.Errorf("jwtProvider.Retrieve() claims = %v, want %v", gotClaims, wantClaims)
+				}
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/elastic/go-sfdc
+
+go 1.21.0
+
+require github.com/golang-jwt/jwt/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/session/session.go
+++ b/session/session.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/credentials"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/credentials"
 )
 
 // Session is the authentication response.  This is used to generate the

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/credentials"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/credentials"
 )
 
 func TestPasswordSessionRequest(t *testing.T) {

--- a/sobject/collections/collections.go
+++ b/sobject/collections/collections.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 const (

--- a/sobject/collections/collections_test.go
+++ b/sobject/collections/collections_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 func Test_collection_send(t *testing.T) {

--- a/sobject/collections/delete.go
+++ b/sobject/collections/delete.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 // DeleteValue is the return value from the

--- a/sobject/collections/delete_test.go
+++ b/sobject/collections/delete_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/sobject"
 
-	"github.com/g8rswimmer/go-sfdc"
+	"github.com/elastic/go-sfdc"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func TestDelete_values(t *testing.T) {

--- a/sobject/collections/insert.go
+++ b/sobject/collections/insert.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 type insert struct {

--- a/sobject/collections/insert_test.go
+++ b/sobject/collections/insert_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 type mockInserter struct {

--- a/sobject/collections/query.go
+++ b/sobject/collections/query.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 type collectionQueryPayload struct {

--- a/sobject/collections/query_test.go
+++ b/sobject/collections/query_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 type mockQuery struct {

--- a/sobject/collections/update.go
+++ b/sobject/collections/update.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 // UpdateValue is the return value from the

--- a/sobject/collections/update_test.go
+++ b/sobject/collections/update_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 type mockUpdater struct {

--- a/sobject/describe.go
+++ b/sobject/describe.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // DescribeValue is a structure that is returned from the from the Salesforce

--- a/sobject/describe_test.go
+++ b/sobject/describe_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func Test_describe_Describe(t *testing.T) {

--- a/sobject/dml.go
+++ b/sobject/dml.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // InsertValue is the value that is returned when a

--- a/sobject/dml_test.go
+++ b/sobject/dml_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
+	"github.com/elastic/go-sfdc"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockInserter struct {

--- a/sobject/framework.go
+++ b/sobject/framework.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // ObjectURLs is the URL for the SObject metadata.

--- a/sobject/framework_test.go
+++ b/sobject/framework_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func TestSalesforceAPI_Metadata(t *testing.T) {

--- a/sobject/metadata.go
+++ b/sobject/metadata.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // MetadataValue is the response from the SObject metadata API.

--- a/sobject/metadata_test.go
+++ b/sobject/metadata_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func Test_metadata_Metadata(t *testing.T) {

--- a/sobject/query.go
+++ b/sobject/query.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Querier is the interface used to query a SObject from

--- a/sobject/query_test.go
+++ b/sobject/query_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockQuery struct {

--- a/sobject/tree/builder.go
+++ b/sobject/tree/builder.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/g8rswimmer/go-sfdc/sobject"
+	"github.com/elastic/go-sfdc/sobject"
 )
 
 // Builder is the SObject Tree builder for the

--- a/sobject/tree/tree.go
+++ b/sobject/tree/tree.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/g8rswimmer/go-sfdc"
+	"github.com/elastic/go-sfdc"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Inserter is used to define the SObject and it's records for the

--- a/sobject/tree/tree_test.go
+++ b/sobject/tree/tree_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockInserter struct {

--- a/soql/query.go
+++ b/soql/query.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/g8rswimmer/go-sfdc"
+	"github.com/elastic/go-sfdc"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 // Resource is the structure for the Salesforce

--- a/soql/query_test.go
+++ b/soql/query_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc/session"
+	"github.com/elastic/go-sfdc/session"
 )
 
 type mockQuerier struct {

--- a/soql/record.go
+++ b/soql/record.go
@@ -1,6 +1,6 @@
 package soql
 
-import "github.com/g8rswimmer/go-sfdc"
+import "github.com/elastic/go-sfdc"
 
 // QueryRecord is the result of the SOQL record.  If
 // the query statement contains an inner query, there

--- a/soql/record_test.go
+++ b/soql/record_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/g8rswimmer/go-sfdc"
+	"github.com/elastic/go-sfdc"
 )
 
 func testQueryRecord(jsonMap map[string]interface{}) *sfdc.Record {


### PR DESCRIPTION
Changes include:

- Initialize Go modules with `go.{mod,sum}`
- Update import path to `github.com/elastic/go-sfdc`
- Replace deprecated `github.com/dgrijalva/jwt-go` with `github.com/golang-jwt/jwt/v5`
- Refactor `jwt{,_test}.go` to accommodate the new `github.com/golang-jwt/jwt/v5` package
- Enhance JWT unit tests in `jwt_test.go` for better coverage and reliability