### PR TITLE
credentials: Add optional token endpoint URL for JWT provider

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -27,10 +27,11 @@ type PasswordCredentials struct {
 }
 
 type JwtCredentials struct {
-	URL				string
-	ClientId 		string // the client id as defined in the connected app in SalesForce
-	ClientUsername 	string
-	ClientKey 		*rsa.PrivateKey  // the client RSA key uploaded for authentication in the ConnectedApp
+	URL            string // Used as the audience URL in the JWT claim
+	TokenURL       string // Optional: The endpoint to send the token request to (if different from URL)
+	ClientId       string // The client id as defined in the connected app in SalesForce
+	ClientUsername string
+	ClientKey      *rsa.PrivateKey // The client RSA key uploaded for authentication in the connected app
 }
 
 // Credentials is the structure that contains all of the
@@ -54,7 +55,7 @@ type grantType string
 
 const (
 	passwordGrantType grantType = "password"
-	jwtGrantType grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+	jwtGrantType      grantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 )
 
 // Retrieve will return the reader for the HTTP request body.
@@ -91,7 +92,9 @@ func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
 
 // NewJWTCredentials weill create a credntial with all required info about generating a JWT claims parameter
 func NewJWTCredentials(creds JwtCredentials) (*Credentials, error) {
-	if err := validateJWTCredentials(creds); err != nil {return nil, err}
+	if err := validateJWTCredentials(creds); err != nil {
+		return nil, err
+	}
 	return &Credentials{
 		provider: &jwtProvider{
 			creds: creds,
@@ -118,14 +121,13 @@ func validatePasswordCredentials(cred PasswordCredentials) error {
 func validateJWTCredentials(cred JwtCredentials) error {
 	switch {
 	case len(cred.URL) == 0:
-		return errors.New("URL cannot be empty")
+		return errors.New("credentials: URL cannot be empty")
 	case cred.ClientKey == nil:
-		return errors.New("client key cannot be empty")
+		return errors.New("credentials: client key cannot be empty")
 	case len(cred.ClientUsername) == 0:
-		return errors.New("client username cannot be empty")
+		return errors.New("credentials: client username cannot be empty")
 	case len(cred.ClientId) == 0:
-		return errors.New("client id cannot be empty")
+		return errors.New("credentials: client id cannot be empty")
 	}
 	return nil
-
 }

--- a/credentials/credentials_test.go
+++ b/credentials/credentials_test.go
@@ -115,7 +115,6 @@ func TestNewPasswordCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			got, err := NewPasswordCredentials(tt.args.creds)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewPasswordCredentials() error = %v, wantErr %v", err, tt.wantErr)

--- a/credentials/jwt.go
+++ b/credentials/jwt.go
@@ -32,9 +32,9 @@ func (provider *jwtProvider) Retrieve() (io.Reader, error) {
 }
 
 // URL returns the endpoint for the token request.
-// If TokenEndpointURL is specified, it will be used; otherwise, falls back to URL.
+// If TokenURL is specified, it will be used; otherwise, falls back to URL.
 func (provider *jwtProvider) URL() string {
-	// Use TokenEndpointURL if provided, otherwise fall back to the original URL (audience)
+	// Use TokenURL if provided, otherwise fall back to the original URL (audience)
 	if provider.creds.TokenURL != "" {
 		return provider.creds.TokenURL
 	}

--- a/credentials/jwt.go
+++ b/credentials/jwt.go
@@ -10,9 +10,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const (
-	JwtExpiration = 3 * time.Minute
-)
+const JwtExpiration = 3 * time.Minute
 
 type jwtProvider struct {
 	creds JwtCredentials
@@ -33,10 +31,17 @@ func (provider *jwtProvider) Retrieve() (io.Reader, error) {
 	return strings.NewReader(form.Encode()), nil
 }
 
+// URL returns the endpoint for the token request.
+// If TokenEndpointURL is specified, it will be used; otherwise, falls back to URL.
 func (provider *jwtProvider) URL() string {
+	// Use TokenEndpointURL if provided, otherwise fall back to the original URL (audience)
+	if provider.creds.TokenURL != "" {
+		return provider.creds.TokenURL
+	}
 	return provider.creds.URL
 }
 
+// GetAppropriateExpirationTime returns a time value for the JWT expiration.
 func (provider *jwtProvider) GetAppropriateExpirationTime() time.Time {
 	if provider.now != nil {
 		return provider.now().Add(JwtExpiration)
@@ -44,7 +49,8 @@ func (provider *jwtProvider) GetAppropriateExpirationTime() time.Time {
 	return time.Now().Add(JwtExpiration)
 }
 
-func (provider *jwtProvider) BuildClaimsToken(expirationTime time.Time, url string, clientId string, clientUsername string) (string, error) {
+// BuildClaimsToken generates a signed JWT token with the specified claims.
+func (provider *jwtProvider) BuildClaimsToken(expirationTime time.Time, url, clientId, clientUsername string) (string, error) {
 	claims := jwt.MapClaims{
 		"iss": clientId,
 		"sub": clientUsername,

--- a/credentials/jwt_test.go
+++ b/credentials/jwt_test.go
@@ -43,6 +43,59 @@ func fixedTime() time.Time {
 	return time.Now()
 }
 
+func Test_jwtProvider_URL(t *testing.T) {
+	tests := []struct {
+		name     string
+		creds    JwtCredentials
+		wantURL  string
+	}{
+		{
+			name: "TokenURL provided - should use TokenURL",
+			creds: JwtCredentials{
+				URL:      "https://login.salesforce.com",
+				TokenURL: "https://custom.my.salesforce.com",
+			},
+			wantURL: "https://custom.my.salesforce.com",
+		},
+		{
+			name: "TokenURL empty - should fall back to URL",
+			creds: JwtCredentials{
+				URL:      "https://login.salesforce.com",
+				TokenURL: "",
+			},
+			wantURL: "https://login.salesforce.com",
+		},
+		{
+			name: "TokenURL not set - should fall back to URL",
+			creds: JwtCredentials{
+				URL: "https://test.salesforce.com",
+			},
+			wantURL: "https://test.salesforce.com",
+		},
+		{
+			name: "Government cloud scenario - different token endpoint",
+			creds: JwtCredentials{
+				URL:      "https://login.salesforce.com",
+				TokenURL: "https://login.salesforce.mil",
+			},
+			wantURL: "https://login.salesforce.mil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &jwtProvider{
+				creds: tt.creds,
+			}
+
+			got := provider.URL()
+			if got != tt.wantURL {
+				t.Errorf("jwtProvider.URL() = %v, want %v", got, tt.wantURL)
+			}
+		})
+	}
+}
+
 func Test_jwtProvider_Retrieve(t *testing.T) {
 	pemData := []byte(SampleKey)
 	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(pemData)

--- a/credentials/password_test.go
+++ b/credentials/password_test.go
@@ -18,6 +18,7 @@ func mockPasswordRetriveReader(creds PasswordCredentials) io.Reader {
 
 	return strings.NewReader(form.Encode())
 }
+
 func Test_passwordProvider_Retrieve(t *testing.T) {
 	type fields struct {
 		creds PasswordCredentials

--- a/session/session.go
+++ b/session/session.go
@@ -72,7 +72,6 @@ func Open(config sfdc.Configuration) (*Session, error) {
 		return nil, errors.New("session: configuration version can not be less than zero")
 	}
 	request, err := passwordSessionRequest(config.Credentials)
-
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +90,6 @@ func Open(config sfdc.Configuration) (*Session, error) {
 }
 
 func passwordSessionRequest(creds *credentials.Credentials) (*http.Request, error) {
-
 	oauthURL := creds.URL() + oauthEndpoint
 
 	body, err := creds.Retrieve()
@@ -100,7 +98,6 @@ func passwordSessionRequest(creds *credentials.Credentials) (*http.Request, erro
 	}
 
 	request, err := http.NewRequest(http.MethodPost, oauthURL, body)
-
 	if err != nil {
 		return nil, err
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestPasswordSessionRequest(t *testing.T) {
-
 	scenarios := []struct {
 		desc  string
 		creds credentials.PasswordCredentials
@@ -90,7 +89,6 @@ func TestPasswordSessionRequest(t *testing.T) {
 			}
 		}
 	}
-
 }
 
 func TestPasswordSessionResponse(t *testing.T) {
@@ -173,7 +171,6 @@ func TestPasswordSessionResponse(t *testing.T) {
 	for _, scenario := range scenarios {
 
 		request, err := http.NewRequest(http.MethodPost, scenario.url, nil)
-
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -227,6 +224,7 @@ func testNewPasswordCredentials(cred credentials.PasswordCredentials) *credentia
 	}
 	return creds
 }
+
 func TestNewPasswordSession(t *testing.T) {
 	scenarios := []struct {
 		desc    string
@@ -308,7 +306,6 @@ func TestNewPasswordSession(t *testing.T) {
 					ClientSecret: "shhhh its a secret",
 				}),
 				Client: mockHTTPClient(func(req *http.Request) *http.Response {
-
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Status:     "Some status",
@@ -445,7 +442,6 @@ func TestSession_AuthorizationHeader(t *testing.T) {
 			if got := tt.args.request.Header.Get("Authorization"); got != tt.want {
 				t.Errorf("Session.AuthorizationHeader() = %v, want %v", got, tt.want)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds an optional `TokenURL` field to `JwtCredentials` to allow specifying a separate token endpoint URL for the JWT Bearer flow.

Note: Made some unrelated logging related and cosmetic changes as well.

## Problem

Currently, the `URL` field in `JwtCredentials` is used for both:
1. The JWT audience claim (`aud`)
2. The token endpoint to request the access token from

This works for standard Salesforce endpoints (`https://login.salesforce.com` or `https://test.salesforce.com`), but fails for users who:
- Use custom Salesforce domains (e.g., `https://mycompany.my.salesforce.com`)
- Have disabled logins for default endpoints

In these cases, the audience URL and token endpoint URL need to be different.

## Solution

Add an optional `TokenURL` field to `JwtCredentials`:
- If `TokenURL` is empty → use `URL` for both audience and token endpoint (existing behavior)
- If `TokenURL` is set → use `URL` for audience claim, `TokenURL` for token endpoint

## Related

- Beats issue: https://github.com/elastic/beats/issues/43963