### PR TITLE
Session HTTP client: refresh once on Salesforce auth expiry

### DIFF
--- a/composite/batch/batch.go
+++ b/composite/batch/batch.go
@@ -47,7 +47,7 @@ type Resource struct {
 	session session.ServiceFormatter
 }
 
-// NewResource creates a new resourse with the session.  If the session is
+// NewResource creates a new resource with the session.  If the session is
 // nil an error will be returned.
 func NewResource(session session.ServiceFormatter) (*Resource, error) {
 	if session == nil {

--- a/composite/composite.go
+++ b/composite/composite.go
@@ -56,7 +56,7 @@ type Resource struct {
 	session session.ServiceFormatter
 }
 
-// NewResource creates a new resourse with the session.  If the session is
+// NewResource creates a new resource with the session.  If the session is
 // nil an error will be returned.
 func NewResource(session session.ServiceFormatter) (*Resource, error) {
 	if session == nil {

--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -78,7 +78,7 @@ func NewCredentials(provider Provider) (*Credentials, error) {
 	}, nil
 }
 
-// NewPasswordCredentials will create a crendential with the password credentials.
+// NewPasswordCredentials will create a credential with the password credentials.
 func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
 	if err := validatePasswordCredentials(creds); err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func NewPasswordCredentials(creds PasswordCredentials) (*Credentials, error) {
 	}, nil
 }
 
-// NewJWTCredentials weill create a credntial with all required info about generating a JWT claims parameter
+// NewJWTCredentials will create credentials with all required info about generating a JWT claims parameter.
 func NewJWTCredentials(creds JwtCredentials) (*Credentials, error) {
 	if err := validateJWTCredentials(creds); err != nil {
 		return nil, err

--- a/credentials/jwt_test.go
+++ b/credentials/jwt_test.go
@@ -8,36 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/go-sfdc/internal/testkeys"
 	"github.com/golang-jwt/jwt/v5"
 )
-
-const SampleKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m
-0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa
-iks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO
-lh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV
-ZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1
-oSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad
-4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA
-OntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC
-qJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I
-eK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5
-tog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH
-5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q
-+smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ
-N1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK
-P/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP
-+dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP
-yWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5
-PI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm
-QKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE
-2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge
-LDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq
-NGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW
-RHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ
-Gqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo
-hQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg
------END RSA PRIVATE KEY-----`
 
 func fixedTime() time.Time {
 	return time.Now()
@@ -45,9 +18,9 @@ func fixedTime() time.Time {
 
 func Test_jwtProvider_URL(t *testing.T) {
 	tests := []struct {
-		name     string
-		creds    JwtCredentials
-		wantURL  string
+		name    string
+		creds   JwtCredentials
+		wantURL string
 	}{
 		{
 			name: "TokenURL provided - should use TokenURL",
@@ -97,11 +70,7 @@ func Test_jwtProvider_URL(t *testing.T) {
 }
 
 func Test_jwtProvider_Retrieve(t *testing.T) {
-	pemData := []byte(SampleKey)
-	signKey, err := jwt.ParseRSAPrivateKeyFromPEM(pemData)
-	if err != nil {
-		t.Fatalf("Failed to parse RSA private key: %v", err)
-	}
+	signKey := testkeys.MustParseRSAPrivateKey(t)
 
 	tests := []struct {
 		name          string

--- a/internal/testkeys/testkeys.go
+++ b/internal/testkeys/testkeys.go
@@ -1,0 +1,48 @@
+package testkeys
+
+import (
+	"crypto/rsa"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const sampleRSAPrivateKeyPEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m
+0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa
+iks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO
+lh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV
+ZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1
+oSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad
+4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA
+OntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC
+qJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I
+eK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5
+tog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH
+5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q
++smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ
+N1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK
+P/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP
++dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP
+yWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5
+PI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm
+QKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE
+2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge
+LDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq
+NGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW
+RHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ
+Gqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo
+hQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg
+-----END RSA PRIVATE KEY-----`
+
+// MustParseRSAPrivateKey returns the shared RSA test key fixture.
+func MustParseRSAPrivateKey(tb testing.TB) *rsa.PrivateKey {
+	tb.Helper()
+
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(sampleRSAPrivateKeyPEM))
+	if err != nil {
+		tb.Fatalf("jwt.ParseRSAPrivateKeyFromPEM() error = %v, want nil", err)
+	}
+
+	return signKey
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1,4 +1,4 @@
-// Package session provides handles creation of a Salesforce session
+// Package session handles creation of a Salesforce session.
 package session
 
 import (
@@ -14,10 +14,10 @@ import (
 	"github.com/elastic/go-sfdc/credentials"
 )
 
-// Session is the authentication response.  This is used to generate the
-// authroization header for the Salesforce API calls.
+// Session is the authentication response. This is used to generate the
+// authorization header for the Salesforce API calls.
 type Session struct {
-	response *sessionPasswordResponse
+	response *oauthTokenResponse
 	config   sfdc.Configuration
 	client   *http.Client
 	mu       sync.RWMutex
@@ -30,7 +30,7 @@ type Clienter interface {
 }
 
 // InstanceFormatter is the session interface that
-// formaters the session instance information used
+// formats the session instance information used
 // by the resources.
 //
 // InstanceURL will return the Salesforce instance.
@@ -47,13 +47,15 @@ type InstanceFormatter interface {
 // formats the session for service resources.
 //
 // ServiceURL provides the service URL for resources to
-// user.
+// use.
 type ServiceFormatter interface {
 	InstanceFormatter
 	ServiceURL() string
 }
 
-type sessionPasswordResponse struct {
+// oauthTokenResponse is the JSON body from POST /services/oauth2/token for
+// standard OAuth grants (e.g. password, JWT bearer), not password-only.
+type oauthTokenResponse struct {
 	AccessToken string `json:"access_token"`
 	InstanceURL string `json:"instance_url"`
 	ID          string `json:"id"`
@@ -69,11 +71,15 @@ var invalidAuthErrorCodes = map[string]struct{}{
 	"INVALID_SESSION_ID":  {},
 }
 
-// Open is used to authenticate with Salesforce and open a session.  The user will need to
+// Open is used to authenticate with Salesforce and open a session. The user will need to
 // supply the proper credentials and a HTTP client.
+//
+// The returned session's Client wraps the configured HTTP client. Requests made
+// through Session.Client() are retried once after a Salesforce-shaped expired
+// authentication response, using the same credential provider to get a new token.
 func Open(config sfdc.Configuration) (*Session, error) {
 	if config.Credentials == nil {
-		return nil, errors.New("session: configuration crendentials can not be nil")
+		return nil, errors.New("session: configuration credentials can not be nil")
 	}
 	if config.Client == nil {
 		return nil, errors.New("session: configuration client can not be nil")
@@ -81,12 +87,12 @@ func Open(config sfdc.Configuration) (*Session, error) {
 	if config.Version <= 0 {
 		return nil, errors.New("session: configuration version can not be less than zero")
 	}
-	request, err := passwordSessionRequest(config.Credentials)
+	request, err := newOAuthTokenRequest(config.Credentials)
 	if err != nil {
 		return nil, err
 	}
 
-	response, err := passwordSessionResponse(request, config.Client)
+	response, err := exchangeOAuthToken(request, config.Client)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +106,9 @@ func Open(config sfdc.Configuration) (*Session, error) {
 	return session, nil
 }
 
-func passwordSessionRequest(creds *credentials.Credentials) (*http.Request, error) {
+// newOAuthTokenRequest builds the token POST for any credentials.Provider
+// (password grant, JWT bearer, or a custom provider).
+func newOAuthTokenRequest(creds *credentials.Credentials) (*http.Request, error) {
 	oauthURL := creds.URL() + oauthEndpoint
 
 	body, err := creds.Retrieve()
@@ -118,7 +126,7 @@ func passwordSessionRequest(creds *credentials.Credentials) (*http.Request, erro
 	return request, nil
 }
 
-func passwordSessionResponse(request *http.Request, client *http.Client) (*sessionPasswordResponse, error) {
+func exchangeOAuthToken(request *http.Request, client *http.Client) (*oauthTokenResponse, error) {
 	response, err := client.Do(request)
 	if err != nil {
 		return nil, err
@@ -130,16 +138,16 @@ func passwordSessionResponse(request *http.Request, client *http.Client) (*sessi
 	decoder := json.NewDecoder(response.Body)
 	defer response.Body.Close()
 
-	var sessionResponse sessionPasswordResponse
-	err = decoder.Decode(&sessionResponse)
+	var token oauthTokenResponse
+	err = decoder.Decode(&token)
 	if err != nil {
 		return nil, err
 	}
 
-	return &sessionResponse, nil
+	return &token, nil
 }
 
-// InstanceURL will retuern the Salesforce instance
+// InstanceURL will return the Salesforce instance
 // from the session authentication.
 func (session *Session) InstanceURL() string {
 	session.mu.RLock()
@@ -161,7 +169,8 @@ func (session *Session) AuthorizationHeader(request *http.Request) {
 	request.Header.Set("Authorization", session.authorizationValue())
 }
 
-// Client returns the HTTP client to be used in APIs calls.
+// Client returns the HTTP client to be used in API calls. The client retries
+// once after Salesforce returns a JSON auth error for an expired session.
 func (session *Session) Client() *http.Client {
 	if session.client != nil {
 		return session.client
@@ -184,12 +193,12 @@ func (session *Session) refresh(failedAuthorization string) error {
 		return nil
 	}
 
-	request, err := passwordSessionRequest(session.config.Credentials)
+	request, err := newOAuthTokenRequest(session.config.Credentials)
 	if err != nil {
 		return err
 	}
 
-	response, err := passwordSessionResponse(request, session.config.Client)
+	response, err := exchangeOAuthToken(request, session.config.Client)
 	if err != nil {
 		return err
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -17,10 +17,11 @@ import (
 // Session is the authentication response. This is used to generate the
 // authorization header for the Salesforce API calls.
 type Session struct {
-	response *oauthTokenResponse
-	config   sfdc.Configuration
-	client   *http.Client
-	mu       sync.RWMutex
+	response  *oauthTokenResponse
+	config    sfdc.Configuration
+	client    *http.Client
+	mu        sync.RWMutex
+	refreshMu sync.Mutex
 }
 
 // Clienter interface provides the HTTP client used by the
@@ -131,12 +132,12 @@ func exchangeOAuthToken(request *http.Request, client *http.Client) (*oauthToken
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("session response error: %d %s", response.StatusCode, response.Status)
 	}
 	decoder := json.NewDecoder(response.Body)
-	defer response.Body.Close()
 
 	var token oauthTokenResponse
 	err = decoder.Decode(&token)
@@ -185,11 +186,10 @@ func (session *Session) authorizationValue() string {
 }
 
 func (session *Session) refresh(failedAuthorization string) error {
-	session.mu.Lock()
-	defer session.mu.Unlock()
+	session.refreshMu.Lock()
+	defer session.refreshMu.Unlock()
 
-	currentAuthorization := fmt.Sprintf("%s %s", session.response.TokenType, session.response.AccessToken)
-	if failedAuthorization != "" && currentAuthorization != failedAuthorization {
+	if failedAuthorization != "" && session.authorizationValue() != failedAuthorization {
 		return nil
 	}
 
@@ -203,7 +203,9 @@ func (session *Session) refresh(failedAuthorization string) error {
 		return err
 	}
 
+	session.mu.Lock()
 	session.response = response
+	session.mu.Unlock()
 	return nil
 }
 
@@ -240,13 +242,22 @@ func (transport *authRefreshTransport) RoundTrip(request *http.Request) (*http.R
 	}
 
 	response, err := transport.base.RoundTrip(request)
-	if err != nil || retryRequest == nil {
-		return response, err
+	if err != nil {
+		return nil, err
+	}
+	if retryRequest == nil {
+		return response, nil
 	}
 
 	invalidAuth, err := isInvalidAuthResponse(response)
-	if err != nil || !invalidAuth {
-		return response, err
+	if err != nil {
+		if response.Body != nil {
+			response.Body.Close()
+		}
+		return nil, err
+	}
+	if !invalidAuth {
+		return response, nil
 	}
 
 	if err := transport.session.refresh(failedAuthorization); err != nil {
@@ -268,6 +279,7 @@ func isInvalidAuthResponse(response *http.Response) (bool, error) {
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
+		response.Body.Close()
 		return false, err
 	}
 	response.Body.Close()

--- a/session/session.go
+++ b/session/session.go
@@ -2,10 +2,13 @@
 package session
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"sync"
 
 	"github.com/elastic/go-sfdc"
 	"github.com/elastic/go-sfdc/credentials"
@@ -16,6 +19,8 @@ import (
 type Session struct {
 	response *sessionPasswordResponse
 	config   sfdc.Configuration
+	client   *http.Client
+	mu       sync.RWMutex
 }
 
 // Clienter interface provides the HTTP client used by the
@@ -59,6 +64,11 @@ type sessionPasswordResponse struct {
 
 const oauthEndpoint = "/services/oauth2/token"
 
+var invalidAuthErrorCodes = map[string]struct{}{
+	"INVALID_AUTH_HEADER": {},
+	"INVALID_SESSION_ID":  {},
+}
+
 // Open is used to authenticate with Salesforce and open a session.  The user will need to
 // supply the proper credentials and a HTTP client.
 func Open(config sfdc.Configuration) (*Session, error) {
@@ -85,6 +95,7 @@ func Open(config sfdc.Configuration) (*Session, error) {
 		response: response,
 		config:   config,
 	}
+	session.client = newRefreshingClient(config.Client, session)
 
 	return session, nil
 }
@@ -131,23 +142,159 @@ func passwordSessionResponse(request *http.Request, client *http.Client) (*sessi
 // InstanceURL will retuern the Salesforce instance
 // from the session authentication.
 func (session *Session) InstanceURL() string {
+	session.mu.RLock()
+	defer session.mu.RUnlock()
 	return session.response.InstanceURL
 }
 
 // ServiceURL will return the Salesforce instance for the
 // service URL.
 func (session *Session) ServiceURL() string {
+	session.mu.RLock()
+	defer session.mu.RUnlock()
 	return fmt.Sprintf("%s/services/data/v%d.0", session.response.InstanceURL, session.config.Version)
 }
 
 // AuthorizationHeader will add the authorization to the
 // HTTP request's header.
 func (session *Session) AuthorizationHeader(request *http.Request) {
-	auth := fmt.Sprintf("%s %s", session.response.TokenType, session.response.AccessToken)
-	request.Header.Add("Authorization", auth)
+	request.Header.Set("Authorization", session.authorizationValue())
 }
 
 // Client returns the HTTP client to be used in APIs calls.
 func (session *Session) Client() *http.Client {
+	if session.client != nil {
+		return session.client
+	}
 	return session.config.Client
+}
+
+func (session *Session) authorizationValue() string {
+	session.mu.RLock()
+	defer session.mu.RUnlock()
+	return fmt.Sprintf("%s %s", session.response.TokenType, session.response.AccessToken)
+}
+
+func (session *Session) refresh(failedAuthorization string) error {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+
+	currentAuthorization := fmt.Sprintf("%s %s", session.response.TokenType, session.response.AccessToken)
+	if failedAuthorization != "" && currentAuthorization != failedAuthorization {
+		return nil
+	}
+
+	request, err := passwordSessionRequest(session.config.Credentials)
+	if err != nil {
+		return err
+	}
+
+	response, err := passwordSessionResponse(request, session.config.Client)
+	if err != nil {
+		return err
+	}
+
+	session.response = response
+	return nil
+}
+
+type salesforceErrorResponse struct {
+	ErrorCode string `json:"errorCode"`
+}
+
+type authRefreshTransport struct {
+	session *Session
+	base    http.RoundTripper
+}
+
+func newRefreshingClient(client *http.Client, session *Session) *http.Client {
+	cloned := *client
+	cloned.Transport = &authRefreshTransport{
+		session: session,
+		base:    transportFor(client),
+	}
+	return &cloned
+}
+
+func transportFor(client *http.Client) http.RoundTripper {
+	if client.Transport != nil {
+		return client.Transport
+	}
+	return http.DefaultTransport
+}
+
+func (transport *authRefreshTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	failedAuthorization := request.Header.Get("Authorization")
+	retryRequest, err := cloneRequestForRetry(request)
+	if err != nil {
+		retryRequest = nil
+	}
+
+	response, err := transport.base.RoundTrip(request)
+	if err != nil || retryRequest == nil {
+		return response, err
+	}
+
+	invalidAuth, err := isInvalidAuthResponse(response)
+	if err != nil || !invalidAuth {
+		return response, err
+	}
+
+	if err := transport.session.refresh(failedAuthorization); err != nil {
+		return response, nil
+	}
+
+	response.Body.Close()
+	transport.session.AuthorizationHeader(retryRequest)
+	return transport.base.RoundTrip(retryRequest)
+}
+
+func isInvalidAuthResponse(response *http.Response) (bool, error) {
+	if response == nil {
+		return false, nil
+	}
+	if response.StatusCode != http.StatusBadRequest && response.StatusCode != http.StatusUnauthorized {
+		return false, nil
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return false, err
+	}
+	response.Body.Close()
+	response.Body = io.NopCloser(bytes.NewReader(body))
+
+	var errorResponses []salesforceErrorResponse
+	if err := json.Unmarshal(body, &errorResponses); err != nil {
+		var errorResponse salesforceErrorResponse
+		if err := json.Unmarshal(body, &errorResponse); err != nil {
+			return false, nil
+		}
+		errorResponses = []salesforceErrorResponse{errorResponse}
+	}
+
+	for _, errorResponse := range errorResponses {
+		if _, ok := invalidAuthErrorCodes[errorResponse.ErrorCode]; ok {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func cloneRequestForRetry(request *http.Request) (*http.Request, error) {
+	cloned := request.Clone(request.Context())
+	if request.Body == nil {
+		return cloned, nil
+	}
+	if request.GetBody == nil {
+		return nil, errors.New("session: request body can not be replayed")
+	}
+
+	body, err := request.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	cloned.Body = body
+	return cloned, nil
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -5,15 +5,45 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/elastic/go-sfdc"
 	"github.com/elastic/go-sfdc/credentials"
+	"github.com/golang-jwt/jwt/v5"
 )
 
-func TestPasswordSessionRequest(t *testing.T) {
+const jwtTestPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m
+0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa
+iks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO
+lh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV
+ZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1
+oSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad
+4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA
+OntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC
+qJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I
+eK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5
+tog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH
+5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q
++smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ
+N1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK
+P/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP
++dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP
+yWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5
+PI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm
+QKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE
+2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge
+LDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq
+NGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW
+RHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ
+Gqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo
+hQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg
+-----END RSA PRIVATE KEY-----`
+
+func TestNewOAuthTokenRequest(t *testing.T) {
 	scenarios := []struct {
 		desc  string
 		creds credentials.PasswordCredentials
@@ -49,7 +79,7 @@ func TestPasswordSessionRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal("password credentials can not return an error for these tests")
 		}
-		request, err := passwordSessionRequest(passwordCreds)
+		request, err := newOAuthTokenRequest(passwordCreds)
 
 		if err != nil && scenario.err == nil {
 			t.Errorf("%s Error was not expected %s", scenario.desc, err.Error())
@@ -91,12 +121,12 @@ func TestPasswordSessionRequest(t *testing.T) {
 	}
 }
 
-func TestPasswordSessionResponse(t *testing.T) {
+func TestExchangeOAuthToken(t *testing.T) {
 	scenarios := []struct {
 		desc     string
 		url      string
 		client   *http.Client
-		response *sessionPasswordResponse
+		response *oauthTokenResponse
 		err      error
 	}{
 		{
@@ -119,7 +149,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			}),
-			response: &sessionPasswordResponse{
+			response: &oauthTokenResponse{
 				AccessToken: "token",
 				InstanceURL: "https://some.salesforce.instance.com",
 				ID:          "https://test.salesforce.com/id/123456789",
@@ -140,7 +170,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			}),
-			response: &sessionPasswordResponse{},
+			response: &oauthTokenResponse{},
 			err:      fmt.Errorf("session response error: %d %s", http.StatusInternalServerError, "Some status"),
 		},
 		{
@@ -163,7 +193,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			}),
-			response: &sessionPasswordResponse{},
+			response: &oauthTokenResponse{},
 			err:      errors.New("invalid character '}' looking for beginning of object key string"),
 		},
 	}
@@ -175,7 +205,7 @@ func TestPasswordSessionResponse(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		response, err := passwordSessionResponse(request, scenario.client)
+		response, err := exchangeOAuthToken(request, scenario.client)
 
 		if err != nil && scenario.err == nil {
 			t.Errorf("%s Error was not expected %s", scenario.desc, err.Error())
@@ -225,7 +255,7 @@ func testNewPasswordCredentials(cred credentials.PasswordCredentials) *credentia
 	return creds
 }
 
-func TestNewPasswordSession(t *testing.T) {
+func TestOpen(t *testing.T) {
 	scenarios := []struct {
 		desc    string
 		config  sfdc.Configuration
@@ -262,7 +292,7 @@ func TestNewPasswordSession(t *testing.T) {
 				Version: 45,
 			},
 			session: &Session{
-				response: &sessionPasswordResponse{
+				response: &oauthTokenResponse{
 					AccessToken: "token",
 					InstanceURL: "https://some.salesforce.instance.com",
 					ID:          "https://test.salesforce.com/id/123456789",
@@ -366,7 +396,7 @@ func TestNewPasswordSession(t *testing.T) {
 
 func TestSession_ServiceURL(t *testing.T) {
 	type fields struct {
-		response *sessionPasswordResponse
+		response *oauthTokenResponse
 		config   sfdc.Configuration
 	}
 	tests := []struct {
@@ -377,7 +407,7 @@ func TestSession_ServiceURL(t *testing.T) {
 		{
 			name: "Passing URL",
 			fields: fields{
-				response: &sessionPasswordResponse{
+				response: &oauthTokenResponse{
 					InstanceURL: "https://www.my.salesforce.instance",
 				},
 				config: sfdc.Configuration{
@@ -402,7 +432,7 @@ func TestSession_ServiceURL(t *testing.T) {
 
 func TestSession_AuthorizationHeader(t *testing.T) {
 	type fields struct {
-		response *sessionPasswordResponse
+		response *oauthTokenResponse
 		config   sfdc.Configuration
 	}
 	type args struct {
@@ -417,7 +447,7 @@ func TestSession_AuthorizationHeader(t *testing.T) {
 		{
 			name: "Authorization Test",
 			fields: fields{
-				response: &sessionPasswordResponse{
+				response: &oauthTokenResponse{
 					TokenType:   "Type",
 					AccessToken: "Access",
 				},
@@ -448,7 +478,7 @@ func TestSession_AuthorizationHeader(t *testing.T) {
 
 func TestSession_Client(t *testing.T) {
 	type fields struct {
-		response *sessionPasswordResponse
+		response *oauthTokenResponse
 		config   sfdc.Configuration
 	}
 	tests := []struct {
@@ -459,7 +489,7 @@ func TestSession_Client(t *testing.T) {
 		{
 			name: "Session Client",
 			fields: fields{
-				response: &sessionPasswordResponse{},
+				response: &oauthTokenResponse{},
 				config: sfdc.Configuration{
 					Client: http.DefaultClient,
 				},
@@ -482,7 +512,7 @@ func TestSession_Client(t *testing.T) {
 
 func TestSession_InstanceURL(t *testing.T) {
 	type fields struct {
-		response *sessionPasswordResponse
+		response *oauthTokenResponse
 		config   sfdc.Configuration
 	}
 	tests := []struct {
@@ -493,7 +523,7 @@ func TestSession_InstanceURL(t *testing.T) {
 		{
 			name: "Passing URL",
 			fields: fields{
-				response: &sessionPasswordResponse{
+				response: &oauthTokenResponse{
 					InstanceURL: "https://www.my.salesforce.instance",
 				},
 				config: sfdc.Configuration{
@@ -645,5 +675,125 @@ func TestSession_ClientReauthenticatesAfterInvalidAuthErrors(t *testing.T) {
 				t.Fatalf("Session.AuthorizationHeader() = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestSession_ClientReauthenticatesWithJWTCredentials(t *testing.T) {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtTestPrivateKey))
+	if err != nil {
+		t.Fatalf("jwt.ParseRSAPrivateKeyFromPEM() error = %v, want nil", err)
+	}
+
+	jwtCreds, err := credentials.NewJWTCredentials(credentials.JwtCredentials{
+		URL:            "https://login.salesforce.example.com",
+		ClientId:       "some client id",
+		ClientUsername: "myusername",
+		ClientKey:      signKey,
+	})
+	if err != nil {
+		t.Fatalf("credentials.NewJWTCredentials() error = %v, want nil", err)
+	}
+
+	authCalls := 0
+	resourceCalls := 0
+	var authGrantTypes []string
+	var authHeaders []string
+
+	client := mockHTTPClient(func(req *http.Request) *http.Response {
+		switch req.URL.Path {
+		case oauthEndpoint:
+			authCalls++
+			body, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll(token request body) error = %v, want nil", err)
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				t.Fatalf("ParseQuery(token request body) error = %v, want nil", err)
+			}
+			authGrantTypes = append(authGrantTypes, values.Get("grant_type"))
+			if values.Get("assertion") == "" {
+				t.Fatal("JWT token request assertion is empty")
+			}
+
+			token := "expired"
+			if authCalls > 1 {
+				token = "refreshed"
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{
+					"access_token": %q,
+					"instance_url": "https://instance.salesforce.example.com",
+					"id": "https://test.salesforce.com/id/123456789",
+					"token_type": "Bearer",
+					"issued_at": "1553568410028",
+					"signature": "hello"
+				}`, token))),
+				Header: make(http.Header),
+			}
+		case "/resource":
+			resourceCalls++
+			authHeaders = append(authHeaders, req.Header.Get("Authorization"))
+			if resourceCalls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Status:     "401 Unauthorized",
+					Body: ioutil.NopCloser(strings.NewReader(`[{
+						"message": "Session expired or invalid",
+						"errorCode": "INVALID_SESSION_ID"
+					}]`)),
+					Header: make(http.Header),
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
+				Header:     make(http.Header),
+			}
+		default:
+			t.Fatalf("unexpected request path %q", req.URL.Path)
+			return nil
+		}
+	})
+
+	session, err := Open(sfdc.Configuration{
+		Credentials: jwtCreds,
+		Client:      client,
+		Version:     45,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v, want nil", err)
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+	session.AuthorizationHeader(request)
+
+	response, err := session.Client().Do(request)
+	if err != nil {
+		t.Fatalf("Session.Client().Do() error = %v, want nil", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("Session.Client().Do() status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if authCalls != 2 {
+		t.Fatalf("auth calls = %d, want 2", authCalls)
+	}
+	if !reflect.DeepEqual(authGrantTypes, []string{"urn:ietf:params:oauth:grant-type:jwt-bearer", "urn:ietf:params:oauth:grant-type:jwt-bearer"}) {
+		t.Fatalf("auth grant types = %v, want JWT bearer grant twice", authGrantTypes)
+	}
+	if resourceCalls != 2 {
+		t.Fatalf("resource calls = %d, want 2", resourceCalls)
+	}
+	if !reflect.DeepEqual(authHeaders, []string{"Bearer expired", "Bearer refreshed"}) {
+		t.Fatalf("authorization headers = %v, want %v", authHeaders, []string{"Bearer expired", "Bearer refreshed"})
 	}
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3,45 +3,41 @@ package session
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/elastic/go-sfdc"
 	"github.com/elastic/go-sfdc/credentials"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/elastic/go-sfdc/internal/testkeys"
 )
 
-const jwtTestPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAwCPdYprMz3AMh4CwK8fPdArUL63RMVYoXXYfzFdluW5XYE5m
-0a5PuNpMoc33i7+JYGOCS1T+ZhoAM2AHO3/BbC2sB5qNNj48ToR7RADgy+pKyaUa
-iks4hWXI2fqzAZR11xFEMkCKl0S7Zn4t/oZkFlXbgI+fxt+ab8+9rXa770pL7yCO
-lh5HLIQ1VUPWJN7JeBiKfSnBowGLuelQ8ot7YJmEhohBUN++5ZrfSqPedeLlDYPV
-ZLYlEaZE6Xtg0lI+prsJ6wiv0IlTwH7yYECc2XE8MjyWAlNEoObK6kbfD0oIQqU1
-oSXkRCp21MHoJ9ZTFJvd+2GArbYTzz0KL/r7TQIDAQABAoIBAQCfXmAnhIyy1pad
-4gC+H5qT/tNmxL6KNJOAihTv8eH/P2WcDQu9id64TeFYKDXWpUU2PPN6toHYgGKA
-OntlP59Ysj1JhUjxoAd3fO2dRzkuCiSEQrzTznaQNw+0tfu6KMDhZYHySJRryefC
-qJBP2Hq2B/rsFLULSLaZXW9PrPdPDxijnq+Mnok8t+1F1LRkhdXAiTAAryLT7V4I
-eK6uMd0bHK776dQy7A0hR55B5NOW/1U5iYHhNMNCw31Tct9Ula5Dt5U+oe69xMd5
-tog7UaESglsovusN65GpXjwsBUN/a4qYXXUEa3ZWhDsuH3b2ekcMRgfsx5QLSDqH
-5nFtX3kFAoGBAPLa4oBmLerzZ68GMU+uKQscN/C8o671UTS7jCbtWcBMUZOGrN3q
-+smpB0YB9W4kALSxYM4LsTQ4n8qkfJz1vlMu6iATcPnG+KlEhVITUHXB/ek5aWfZ
-N1uZDGUlg0sgWSlubnNs5xl6J8tYGRrk84g5i6QCSYxesoJ+M/1P7yozAoGBAMqK
-P/PYkbJWq/gh3KcrbbiQhjz6EoPlypcjBzdfQnPamJ94voh2YYNETlDXTSr5bATP
-+dooSaw6lkoDIzZg9IZrq9FDOwXjHptpakpIkYKXKxLVcBl6PrD/hv7jznawdLrP
-yWr9nkqIVHvJxMGvjg7ONgJhCuCHmecrO50p4sR/AoGAa/8aqq7FzK3hddvzIdP5
-PI+X8N5yi+Nb8W9VrBnwx6sou8owJZ/RVsxsB53nXstz5ObcfcSFUQu9Q4hSQhqm
-QKekRg9fNjRdcCiggRdFuJhEKer2DNBz5a/x6yj7cfU4sUwCoiHTw2inOa47u9IE
-2pd8mbrKqjmSeKVWyVc6rDECgYAlrp0BYByTQn7SNnKYA4NxYCopdBk3wuvzPIge
-LDHv3g6hNNS2DNhNlMrBTZ1EzozjRFJm3TH/whKuCHFnr5gu3h9kWo7DpKLQJUeq
-NGAmHLvd0CoAA3dgdNoH2BhUirXc/8WoizEFCuI0+bAKnP/gD0uLG8TrSy8+DBQW
-RHG1PwKBgBAsnnjH4KplKrzfMycTczHEM1pll/wWBe38TbA7YjrOYLGJkac0UVVQ
-Gqhoj3JfpSlWoUbMrOlyY7FlIptmj71P+xPNThKTcc42KMzYJCPhdMllXWktwWKo
-hQZsXUbv/2dzOsyQZWcWM/k+kVArS4+Q3eStBNxaDl0aNQC9CUUg
------END RSA PRIVATE KEY-----`
+type trackingReadCloser struct {
+	reader io.Reader
+	closed bool
+}
+
+func (body *trackingReadCloser) Read(p []byte) (int, error) {
+	return body.reader.Read(p)
+}
+
+func (body *trackingReadCloser) Close() error {
+	body.closed = true
+	return nil
+}
+
+type errReader struct {
+	err error
+}
+
+func (reader errReader) Read([]byte) (int, error) {
+	return 0, reader.err
+}
 
 func TestNewOAuthTokenRequest(t *testing.T) {
 	scenarios := []struct {
@@ -244,6 +240,161 @@ func TestExchangeOAuthToken(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestExchangeOAuthToken_ClosesResponseBodyOnStatusError(t *testing.T) {
+	body := &trackingReadCloser{reader: strings.NewReader(`{"error":"boom"}`)}
+	client := mockHTTPClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       body,
+			Header:     make(http.Header),
+		}
+	})
+
+	request, err := http.NewRequest(http.MethodPost, "http://example.com/foo", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+
+	_, err = exchangeOAuthToken(request, client)
+	if err == nil {
+		t.Fatal("exchangeOAuthToken() error = nil, want non-nil")
+	}
+	if !body.closed {
+		t.Fatal("exchangeOAuthToken() did not close response body on status error")
+	}
+}
+
+func TestAuthRefreshTransport_RoundTripReturnsNilResponseOnInspectionError(t *testing.T) {
+	readErr := errors.New("read failure")
+	body := &trackingReadCloser{reader: errReader{err: readErr}}
+	transport := &authRefreshTransport{
+		session: &Session{},
+		base: roundTripFunc(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Status:     "401 Unauthorized",
+				Body:       body,
+				Header:     make(http.Header),
+			}
+		}),
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+	request.Header.Set("Authorization", "Bearer expired")
+
+	response, err := transport.RoundTrip(request)
+	if err == nil {
+		t.Fatal("RoundTrip() error = nil, want non-nil")
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("RoundTrip() error = %v, want %v", err, readErr)
+	}
+	if response != nil {
+		t.Fatalf("RoundTrip() response = %#v, want nil", response)
+	}
+	if !body.closed {
+		t.Fatal("RoundTrip() did not close response body on inspection error")
+	}
+}
+
+func TestSessionRefresh_DoesNotBlockAuthorizationHeader(t *testing.T) {
+	passwordCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
+		URL:          "https://login.salesforce.example.com",
+		Username:     "myusername",
+		Password:     "12345",
+		ClientID:     "some client id",
+		ClientSecret: "shhhh its a secret",
+	})
+	if err != nil {
+		t.Fatalf("credentials.NewPasswordCredentials() error = %v, want nil", err)
+	}
+
+	authStarted := make(chan struct{})
+	releaseAuth := make(chan struct{})
+	refreshDone := make(chan error, 1)
+	client := mockHTTPClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != oauthEndpoint {
+			t.Fatalf("unexpected request path %q", req.URL.Path)
+		}
+		close(authStarted)
+		<-releaseAuth
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: ioutil.NopCloser(strings.NewReader(`{
+				"access_token": "refreshed",
+				"instance_url": "https://instance.salesforce.example.com",
+				"id": "https://test.salesforce.com/id/123456789",
+				"token_type": "Bearer",
+				"issued_at": "1553568410028",
+				"signature": "hello"
+			}`)),
+			Header: make(http.Header),
+		}
+	})
+
+	session := &Session{
+		response: &oauthTokenResponse{
+			AccessToken: "expired",
+			InstanceURL: "https://instance.salesforce.example.com",
+			ID:          "https://test.salesforce.com/id/123456789",
+			TokenType:   "Bearer",
+			IssuedAt:    "1553568410028",
+			Signature:   "hello",
+		},
+		config: sfdc.Configuration{
+			Credentials: passwordCreds,
+			Client:      client,
+			Version:     45,
+		},
+	}
+
+	go func() {
+		refreshDone <- session.refresh("Bearer expired")
+	}()
+
+	<-authStarted
+
+	request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+
+	authHeaderDone := make(chan struct{})
+	go func() {
+		session.AuthorizationHeader(request)
+		close(authHeaderDone)
+	}()
+
+	select {
+	case <-authHeaderDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("AuthorizationHeader blocked while refresh was in flight")
+	}
+
+	if got, want := request.Header.Get("Authorization"), "Bearer expired"; got != want {
+		t.Fatalf("AuthorizationHeader() = %q, want %q while refresh is in flight", got, want)
+	}
+
+	close(releaseAuth)
+
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("refresh() error = %v, want nil", err)
+	}
+
+	nextRequest, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+	session.AuthorizationHeader(nextRequest)
+	if got, want := nextRequest.Header.Get("Authorization"), "Bearer refreshed"; got != want {
+		t.Fatalf("AuthorizationHeader() = %q, want %q after refresh completes", got, want)
 	}
 }
 
@@ -679,16 +830,11 @@ func TestSession_ClientReauthenticatesAfterInvalidAuthErrors(t *testing.T) {
 }
 
 func TestSession_ClientReauthenticatesWithJWTCredentials(t *testing.T) {
-	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(jwtTestPrivateKey))
-	if err != nil {
-		t.Fatalf("jwt.ParseRSAPrivateKeyFromPEM() error = %v, want nil", err)
-	}
-
 	jwtCreds, err := credentials.NewJWTCredentials(credentials.JwtCredentials{
 		URL:            "https://login.salesforce.example.com",
 		ClientId:       "some client id",
 		ClientUsername: "myusername",
-		ClientKey:      signKey,
+		ClientKey:      testkeys.MustParseRSAPrivateKey(t),
 	})
 	if err != nil {
 		t.Fatalf("credentials.NewJWTCredentials() error = %v, want nil", err)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -515,3 +515,111 @@ func TestSession_InstanceURL(t *testing.T) {
 		})
 	}
 }
+
+func TestSession_ClientReauthenticatesAfterInvalidAuthHeader(t *testing.T) {
+	passwordCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
+		URL:          "https://login.salesforce.example.com",
+		Username:     "myusername",
+		Password:     "12345",
+		ClientID:     "some client id",
+		ClientSecret: "shhhh its a secret",
+	})
+	if err != nil {
+		t.Fatalf("credentials.NewPasswordCredentials() error = %v, want nil", err)
+	}
+
+	authCalls := 0
+	resourceCalls := 0
+	var authHeaders []string
+
+	client := mockHTTPClient(func(req *http.Request) *http.Response {
+		switch req.URL.Path {
+		case oauthEndpoint:
+			authCalls++
+			token := "expired"
+			if authCalls > 1 {
+				token = "refreshed"
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{
+					"access_token": %q,
+					"instance_url": "https://instance.salesforce.example.com",
+					"id": "https://test.salesforce.com/id/123456789",
+					"token_type": "Bearer",
+					"issued_at": "1553568410028",
+					"signature": "hello"
+				}`, token))),
+				Header: make(http.Header),
+			}
+		case "/resource":
+			resourceCalls++
+			authHeaders = append(authHeaders, req.Header.Get("Authorization"))
+			if resourceCalls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Status:     "400 Bad Request",
+					Body: ioutil.NopCloser(strings.NewReader(`[{
+						"message": "Session expired or invalid",
+						"errorCode": "INVALID_AUTH_HEADER"
+					}]`)),
+					Header: make(http.Header),
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
+				Header:     make(http.Header),
+			}
+		default:
+			t.Fatalf("unexpected request path %q", req.URL.Path)
+			return nil
+		}
+	})
+
+	session, err := Open(sfdc.Configuration{
+		Credentials: passwordCreds,
+		Client:      client,
+		Version:     45,
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v, want nil", err)
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+	session.AuthorizationHeader(request)
+
+	response, err := session.Client().Do(request)
+	if err != nil {
+		t.Fatalf("Session.Client().Do() error = %v, want nil", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("Session.Client().Do() status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+	if authCalls != 2 {
+		t.Fatalf("auth calls = %d, want 2", authCalls)
+	}
+	if resourceCalls != 2 {
+		t.Fatalf("resource calls = %d, want 2", resourceCalls)
+	}
+	if !reflect.DeepEqual(authHeaders, []string{"Bearer expired", "Bearer refreshed"}) {
+		t.Fatalf("authorization headers = %v, want %v", authHeaders, []string{"Bearer expired", "Bearer refreshed"})
+	}
+
+	nextRequest, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v, want nil", err)
+	}
+	session.AuthorizationHeader(nextRequest)
+	if got, want := nextRequest.Header.Get("Authorization"), "Bearer refreshed"; got != want {
+		t.Fatalf("Session.AuthorizationHeader() = %q, want %q", got, want)
+	}
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -516,110 +516,134 @@ func TestSession_InstanceURL(t *testing.T) {
 	}
 }
 
-func TestSession_ClientReauthenticatesAfterInvalidAuthHeader(t *testing.T) {
-	passwordCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
-		URL:          "https://login.salesforce.example.com",
-		Username:     "myusername",
-		Password:     "12345",
-		ClientID:     "some client id",
-		ClientSecret: "shhhh its a secret",
-	})
-	if err != nil {
-		t.Fatalf("credentials.NewPasswordCredentials() error = %v, want nil", err)
+func TestSession_ClientReauthenticatesAfterInvalidAuthErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		status     string
+		errorCode  string
+	}{
+		{
+			name:       "invalid auth header",
+			statusCode: http.StatusBadRequest,
+			status:     "400 Bad Request",
+			errorCode:  "INVALID_AUTH_HEADER",
+		},
+		{
+			name:       "invalid session id",
+			statusCode: http.StatusUnauthorized,
+			status:     "401 Unauthorized",
+			errorCode:  "INVALID_SESSION_ID",
+		},
 	}
 
-	authCalls := 0
-	resourceCalls := 0
-	var authHeaders []string
-
-	client := mockHTTPClient(func(req *http.Request) *http.Response {
-		switch req.URL.Path {
-		case oauthEndpoint:
-			authCalls++
-			token := "expired"
-			if authCalls > 1 {
-				token = "refreshed"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			passwordCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
+				URL:          "https://login.salesforce.example.com",
+				Username:     "myusername",
+				Password:     "12345",
+				ClientID:     "some client id",
+				ClientSecret: "shhhh its a secret",
+			})
+			if err != nil {
+				t.Fatalf("credentials.NewPasswordCredentials() error = %v, want nil", err)
 			}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{
-					"access_token": %q,
-					"instance_url": "https://instance.salesforce.example.com",
-					"id": "https://test.salesforce.com/id/123456789",
-					"token_type": "Bearer",
-					"issued_at": "1553568410028",
-					"signature": "hello"
-				}`, token))),
-				Header: make(http.Header),
-			}
-		case "/resource":
-			resourceCalls++
-			authHeaders = append(authHeaders, req.Header.Get("Authorization"))
-			if resourceCalls == 1 {
-				return &http.Response{
-					StatusCode: http.StatusBadRequest,
-					Status:     "400 Bad Request",
-					Body: ioutil.NopCloser(strings.NewReader(`[{
-						"message": "Session expired or invalid",
-						"errorCode": "INVALID_AUTH_HEADER"
-					}]`)),
-					Header: make(http.Header),
+			authCalls := 0
+			resourceCalls := 0
+			var authHeaders []string
+
+			client := mockHTTPClient(func(req *http.Request) *http.Response {
+				switch req.URL.Path {
+				case oauthEndpoint:
+					authCalls++
+					token := "expired"
+					if authCalls > 1 {
+						token = "refreshed"
+					}
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{
+							"access_token": %q,
+							"instance_url": "https://instance.salesforce.example.com",
+							"id": "https://test.salesforce.com/id/123456789",
+							"token_type": "Bearer",
+							"issued_at": "1553568410028",
+							"signature": "hello"
+						}`, token))),
+						Header: make(http.Header),
+					}
+				case "/resource":
+					resourceCalls++
+					authHeaders = append(authHeaders, req.Header.Get("Authorization"))
+					if resourceCalls == 1 {
+						return &http.Response{
+							StatusCode: tt.statusCode,
+							Status:     tt.status,
+							Body: ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`[{
+								"message": "Session expired or invalid",
+								"errorCode": %q
+							}]`, tt.errorCode))),
+							Header: make(http.Header),
+						}
+					}
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
+						Header:     make(http.Header),
+					}
+				default:
+					t.Fatalf("unexpected request path %q", req.URL.Path)
+					return nil
 				}
+			})
+
+			session, err := Open(sfdc.Configuration{
+				Credentials: passwordCreds,
+				Client:      client,
+				Version:     45,
+			})
+			if err != nil {
+				t.Fatalf("Open() error = %v, want nil", err)
 			}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Status:     "200 OK",
-				Body:       ioutil.NopCloser(strings.NewReader(`{}`)),
-				Header:     make(http.Header),
+			request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+			if err != nil {
+				t.Fatalf("http.NewRequest() error = %v, want nil", err)
 			}
-		default:
-			t.Fatalf("unexpected request path %q", req.URL.Path)
-			return nil
-		}
-	})
+			session.AuthorizationHeader(request)
 
-	session, err := Open(sfdc.Configuration{
-		Credentials: passwordCreds,
-		Client:      client,
-		Version:     45,
-	})
-	if err != nil {
-		t.Fatalf("Open() error = %v, want nil", err)
-	}
+			response, err := session.Client().Do(request)
+			if err != nil {
+				t.Fatalf("Session.Client().Do() error = %v, want nil", err)
+			}
+			defer response.Body.Close()
 
-	request, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v, want nil", err)
-	}
-	session.AuthorizationHeader(request)
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("Session.Client().Do() status = %d, want %d", response.StatusCode, http.StatusOK)
+			}
+			if authCalls != 2 {
+				t.Fatalf("auth calls = %d, want 2", authCalls)
+			}
+			if resourceCalls != 2 {
+				t.Fatalf("resource calls = %d, want 2", resourceCalls)
+			}
+			if !reflect.DeepEqual(authHeaders, []string{"Bearer expired", "Bearer refreshed"}) {
+				t.Fatalf("authorization headers = %v, want %v", authHeaders, []string{"Bearer expired", "Bearer refreshed"})
+			}
 
-	response, err := session.Client().Do(request)
-	if err != nil {
-		t.Fatalf("Session.Client().Do() error = %v, want nil", err)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		t.Fatalf("Session.Client().Do() status = %d, want %d", response.StatusCode, http.StatusOK)
-	}
-	if authCalls != 2 {
-		t.Fatalf("auth calls = %d, want 2", authCalls)
-	}
-	if resourceCalls != 2 {
-		t.Fatalf("resource calls = %d, want 2", resourceCalls)
-	}
-	if !reflect.DeepEqual(authHeaders, []string{"Bearer expired", "Bearer refreshed"}) {
-		t.Fatalf("authorization headers = %v, want %v", authHeaders, []string{"Bearer expired", "Bearer refreshed"})
-	}
-
-	nextRequest, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
-	if err != nil {
-		t.Fatalf("http.NewRequest() error = %v, want nil", err)
-	}
-	session.AuthorizationHeader(nextRequest)
-	if got, want := nextRequest.Header.Get("Authorization"), "Bearer refreshed"; got != want {
-		t.Fatalf("Session.AuthorizationHeader() = %q, want %q", got, want)
+			nextRequest, err := http.NewRequest(http.MethodGet, "https://instance.salesforce.example.com/resource", nil)
+			if err != nil {
+				t.Fatalf("http.NewRequest() error = %v, want nil", err)
+			}
+			session.AuthorizationHeader(nextRequest)
+			if got, want := nextRequest.Header.Get("Authorization"), "Bearer refreshed"; got != want {
+				t.Fatalf("Session.AuthorizationHeader() = %q, want %q", got, want)
+			}
+		})
 	}
 }

--- a/sobject/tree/tree.go
+++ b/sobject/tree/tree.go
@@ -53,7 +53,7 @@ func NewResource(session session.ServiceFormatter) (*Resource, error) {
 // Insert will call the composite tree API.
 func (r *Resource) Insert(inserter Inserter) (*Value, error) {
 	if inserter == nil {
-		return nil, errors.New("tree resourse: inserter can not be nil")
+		return nil, errors.New("tree resource: inserter can not be nil")
 	}
 	sobject := inserter.SObject()
 	matching, err := regexp.MatchString(`\w`, sobject)
@@ -61,7 +61,7 @@ func (r *Resource) Insert(inserter Inserter) (*Value, error) {
 		return nil, err
 	}
 	if matching == false {
-		return nil, fmt.Errorf("tree resourse: %s is not a valid sobject", sobject)
+		return nil, fmt.Errorf("tree resource: %s is not a valid sobject", sobject)
 	}
 
 	return r.callout(inserter)

--- a/soql/result_test.go
+++ b/soql/result_test.go
@@ -1,11 +1,16 @@
 package soql
 
 import (
-	"io/ioutil"
+	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/elastic/go-sfdc"
+	"github.com/elastic/go-sfdc/credentials"
+	"github.com/elastic/go-sfdc/session"
 )
 
 func testNewQueryRecords(records []map[string]interface{}) []*QueryRecord {
@@ -308,7 +313,7 @@ func TestQueryResult_Next(t *testing.T) {
 								return &http.Response{
 									StatusCode: 500,
 									Status:     "Some Status",
-									Body:       ioutil.NopCloser(strings.NewReader("Error")),
+									Body:       io.NopCloser(strings.NewReader("Error")),
 									Header:     make(http.Header),
 								}
 							}
@@ -339,7 +344,7 @@ func TestQueryResult_Next(t *testing.T) {
 
 							return &http.Response{
 								StatusCode: 200,
-								Body:       ioutil.NopCloser(strings.NewReader(resp)),
+								Body:       io.NopCloser(strings.NewReader(resp)),
 								Header:     make(http.Header),
 							}
 						}),
@@ -406,5 +411,153 @@ func TestQueryResult_Next(t *testing.T) {
 				t.Errorf("QueryResult.Next() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestQueryResult_NextReauthenticatesAfterInvalidSessionID(t *testing.T) {
+	passwordCreds, err := credentials.NewPasswordCredentials(credentials.PasswordCredentials{
+		URL:          "https://login.salesforce.example.com",
+		Username:     "myusername",
+		Password:     "12345",
+		ClientID:     "some client id",
+		ClientSecret: "shhhh its a secret",
+	})
+	if err != nil {
+		t.Fatalf("credentials.NewPasswordCredentials() error = %v, want nil", err)
+	}
+
+	authCalls := 0
+	queryCalls := 0
+	nextCalls := 0
+	var nextAuthHeaders []string
+
+	client := mockHTTPClient(func(req *http.Request) *http.Response {
+		switch req.URL.Path {
+		case "/services/oauth2/token":
+			authCalls++
+			token := "expired"
+			if authCalls > 1 {
+				token = "refreshed"
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{
+					"access_token": %q,
+					"instance_url": "https://instance.salesforce.example.com",
+					"id": "https://test.salesforce.com/id/123456789",
+					"token_type": "Bearer",
+					"issued_at": "1553568410028",
+					"signature": "hello"
+				}`, token))),
+				Header: make(http.Header),
+			}
+		case "/services/data/v45.0/query/":
+			queryCalls++
+			if got, want := req.URL.Query().Get("q"), "SELECT Name FROM Account"; got != want {
+				t.Fatalf("query = %q, want %q", got, want)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"done": false,
+					"totalSize": 2,
+					"nextRecordsUrl": "/services/data/v45.0/query/01gD0000002HU6KIAW-2000",
+					"records": [
+						{
+							"attributes": {
+								"type": "Account",
+								"url": "/services/data/v45.0/sobjects/Account/001D000000IRFmaIAH"
+							},
+							"Name": "Test 1"
+						}
+					]
+				}`)),
+				Header: make(http.Header),
+			}
+		case "/services/data/v45.0/query/01gD0000002HU6KIAW-2000":
+			nextCalls++
+			nextAuthHeaders = append(nextAuthHeaders, req.Header.Get("Authorization"))
+			if nextCalls == 1 {
+				return &http.Response{
+					StatusCode: http.StatusUnauthorized,
+					Status:     "401 Unauthorized",
+					Body: io.NopCloser(strings.NewReader(`{
+						"message": "Session expired or invalid",
+						"errorCode": "INVALID_SESSION_ID"
+					}`)),
+					Header: make(http.Header),
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"done": true,
+					"totalSize": 2,
+					"records": [
+						{
+							"attributes": {
+								"type": "Account",
+								"url": "/services/data/v45.0/sobjects/Account/001D000000IomazIAB"
+							},
+							"Name": "Test 2"
+						}
+					]
+				}`)),
+				Header: make(http.Header),
+			}
+		default:
+			t.Fatalf("unexpected request path %q", req.URL.Path)
+			return nil
+		}
+	})
+
+	sess, err := session.Open(sfdc.Configuration{
+		Credentials: passwordCreds,
+		Client:      client,
+		Version:     45,
+	})
+	if err != nil {
+		t.Fatalf("session.Open() error = %v, want nil", err)
+	}
+
+	resource, err := NewResource(sess)
+	if err != nil {
+		t.Fatalf("NewResource() error = %v, want nil", err)
+	}
+
+	result, err := resource.Query(&mockQuerier{stmt: "SELECT Name FROM Account"}, false)
+	if err != nil {
+		t.Fatalf("Resource.Query() error = %v, want nil", err)
+	}
+	if !result.MoreRecords() {
+		t.Fatal("QueryResult.MoreRecords() = false, want true")
+	}
+
+	next, err := result.Next()
+	if err != nil {
+		t.Fatalf("QueryResult.Next() error = %v, want nil", err)
+	}
+
+	if authCalls != 2 {
+		t.Fatalf("auth calls = %d, want 2", authCalls)
+	}
+	if queryCalls != 1 {
+		t.Fatalf("query calls = %d, want 1", queryCalls)
+	}
+	if nextCalls != 2 {
+		t.Fatalf("next calls = %d, want 2", nextCalls)
+	}
+	if !reflect.DeepEqual(nextAuthHeaders, []string{"Bearer expired", "Bearer refreshed"}) {
+		t.Fatalf("next authorization headers = %v, want %v", nextAuthHeaders, []string{"Bearer expired", "Bearer refreshed"})
+	}
+	got, ok := next.Records()[0].Record().FieldValue("Name")
+	if !ok {
+		t.Fatal("next record field Name missing")
+	}
+	if want := "Test 2"; got != want {
+		t.Fatalf("next record name = %v, want %v", got, want)
 	}
 }

--- a/soql/result_test.go
+++ b/soql/result_test.go
@@ -483,10 +483,10 @@ func TestQueryResult_NextReauthenticatesAfterInvalidSessionID(t *testing.T) {
 				return &http.Response{
 					StatusCode: http.StatusUnauthorized,
 					Status:     "401 Unauthorized",
-					Body: io.NopCloser(strings.NewReader(`{
+					Body: io.NopCloser(strings.NewReader(`[{
 						"message": "Session expired or invalid",
 						"errorCode": "INVALID_SESSION_ID"
-					}`)),
+					}]`)),
 					Header: make(http.Header),
 				}
 			}


### PR DESCRIPTION
### Summary
Improves Salesforce session handling by wrapping the configured `http.Client` so API calls that receive Salesforce-shaped expired-auth errors can obtain a new access token once and retry the same request with an updated `Authorization` header. Adds regression coverage for password and JWT credential flows and for SOQL pagination via `QueryResult.Next()`.
### Behavior
- On `400` / `401` responses whose JSON body includes `INVALID_AUTH_HEADER` or `INVALID_SESSION_ID`, the session re-runs the OAuth token exchange using the existing `credentials.Provider` (password or JWT bearer), updates stored tokens under a mutex, and retries the original HTTP request once.
- Token exchange still uses the original configured client (not the wrapped client) to avoid recursive refresh.
- `AuthorizationHeader` uses `Set` instead of `Add` to avoid duplicate auth headers.
- `Session.Client()` returns the wrapped client; callers must use it for automatic refresh (documented on `Open` / `Client`).
### Tests
- Table-driven session test for both `INVALID_AUTH_HEADER` and `INVALID_SESSION_ID`.
- JWT-backed test proving refresh issues a second JWT-bearer token request after `INVALID_SESSION_ID`.
- SOQL test: first page succeeds, `Next()` hits `INVALID_SESSION_ID`, refresh, second page succeeds (array-shaped error body).
### Naming / docs / polish
- Renamed internal OAuth helpers for clarity (`newOAuthTokenRequest`, `exchangeOAuthToken`, `oauthTokenResponse`); aligned test names.
- Fixed session package comments and a few comment typos elsewhere; corrected `sobject/tree` error message prefix spelling (`resourse` → `resource`).
- **Note:** `session.Open` nil-credentials error text was corrected (`crendentials` → `credentials`); downstream code that asserts exact error strings may need a trivial test update.